### PR TITLE
Bug fix: Don't use acorn just because file ends with comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (src, file) {
     if (typeof src !== 'string') src = String(src);
     
     try {
-        eval('throw "STOP"; (function () { ' + src + '})()');
+        eval('throw "STOP"; (function () { ' + src + '\n})()');
         return;
     }
     catch (err) {


### PR DESCRIPTION
If a file ends with a single-line comment, then in the quick-eval test, the "})()" appended to the end is commented out, the file unnecessarily fails the quick-eval test, and then the file is parsed with acorn.

When using browserify with sourcemaps enabled, it appears that every source string processed here ends with a single-line comment containing the sourcemap, so everything gets parsed by acorn here. I noticed this while using a profiler on a project's build.

This pull requests makes it so "\n})()" is appended to the end, preventing files ending in single-line comments from triggering an acorn parse.